### PR TITLE
adds gzip package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -62,7 +62,8 @@ container_image(
         packages["libcurl3"],
         packages["curl"],
         packages["git"],
-        packages["coreutils"]
+        packages["coreutils"],
+        packages["gzip"]
     ],
     env = {"PATH": "$PATH:/nodejs/bin/"},
     repository = "drydock/distrobase"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,7 +101,8 @@ dpkg_list(
         "libcurl3",
         "curl",
         "git",
-        "coreutils"
+        "coreutils",
+        "gzip"
     ],
     sources = [
         "@debian_stretch_security//file:Packages.json",


### PR DESCRIPTION
Raising a PR for fixing https://github.com/Shippable/heap/issues/3046

Since it is a straightforward fix and people are blocked on it, opening a PR directly.

```
# Built reqProc with the distrobase image that contains these changes and tried running gzip inside 

vagrant@ubuntu-xenial:~/x/kermit-reqProc$ sudo docker run --rm -it --entrypoint=bash drydock/kermit-u16reqproc:master
root@3d504e507e45:/# gzip
gzip: compressed data not written to a terminal. Use -f to force compression.
For help, type: gzip -h

```