### PR TITLE
installs nodejs 8.16.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,7 @@ load("@package_bundle//file:packages.bzl", "packages")
 
 container_image(
     name = "master",
-    base = "@nodejs//image:image.tar",
+    base = "@cc//image:image.tar",
     debs = [
         packages["libssl1.0.2"],
         packages["openssh-client"],
@@ -65,6 +65,8 @@ container_image(
         packages["coreutils"],
         packages["gzip"]
     ],
+    entrypoint = ["/nodejs/bin/node"],
+    tars = ["@nodejs//:tar"],
     env = {"PATH": "$PATH:/nodejs/bin/"},
     repository = "drydock/distrobase"
 )

--- a/BUILD.nodejs
+++ b/BUILD.nodejs
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "tar",
+    srcs = glob(
+        ["**/*"],
+        exclude = [
+            "WORKSPACE",
+            "*.tar.gz",
+            "BUILD.bazel",
+        ],
+    ),
+    package_dir = "/nodejs",
+    strip_prefix = ".",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,9 +128,18 @@ container_repositories()
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
-    name = "nodejs",
+    name = "cc",
     registry = "gcr.io",
-    repository = "distroless/nodejs",
-    digest = "sha256:35da7f3e98660f26928cfc260591a6bb8e4e9fbe4680da1532e4f8586967838a",
+    repository = "distroless/cc",
+    digest = "sha256:f4dddc007e81bf9a8dfbf6a07a0db5c70292bed76dca896f7d4833f6f33eed2f",
     tag = "latest"
+)
+
+http_archive(
+    name = "nodejs",
+    build_file = "//:BUILD.nodejs",
+    sha256 = "b391450e0fead11f61f119ed26c713180cfe64b363cd945bac229130dfab64fa",
+    strip_prefix = "node-v8.16.0-linux-x64/",
+    type = "tar.gz",
+    urls = ["https://nodejs.org/dist/v8.16.0/node-v8.16.0-linux-x64.tar.gz"],
 )


### PR DESCRIPTION
https://github.com/dry-dock/distrobase/issues/5

```
$ docker run --rm -it drydock/distrobase:master
# results in an interactive nodejs prompt

$ docker run --rm drydock/distrobase:master --version
v8.16.0

# After building all microservices with this base image
$ docker exec -it api node --version
v8.16.0

$ docker exec -it www node --version
v8.16.0
```
